### PR TITLE
fix(queueingmodel): propagate explicit SLO targets from default configuration

### DIFF
--- a/internal/engines/saturation/engine_queueing_model.go
+++ b/internal/engines/saturation/engine_queueing_model.go
@@ -162,6 +162,15 @@ func buildQMConfig(
 		if defaultCfg.SLOMultiplier > 1.0 {
 			cfg.SLOMultiplier = defaultCfg.SLOMultiplier
 		}
+		if defaultCfg.TargetTTFT > 0 && defaultCfg.TargetITL > 0 {
+			modelKey := queueingmodel.MakeModelKey(namespace, modelID)
+			cfg.SLOTargets = map[string]*queueingmodel.SLOTarget{
+				modelKey: {
+					TargetTTFT: defaultCfg.TargetTTFT,
+					TargetITL:  defaultCfg.TargetITL,
+				},
+			}
+		}
 	}
 
 	// Scan for a per-model override matching this model


### PR DESCRIPTION
Fixes a bug where explicitly configured SLO targets in the default configuration block were being ignored during metric initialization and fallbacks. This resolves the `MetricsMissing` issue encountered during autoscaler cold starts.